### PR TITLE
Switch comments from Disqus to Giscus (ad-free)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -200,9 +200,14 @@ google:
 
 # Comments
 comments:
-  provider: "disqus"
-  disqus:
-    shortname: "haksoat-github-io"
+  provider: "giscus"
+  giscus:
+    repo_id: "MDEwOlJlcG9zaXRvcnkxODA0ODE3NDM="
+    category_name: "Announcements"
+    category_id: "DIC_kwDOCsHuz84C6COK"
+    discussion_term: "pathname"
+    reactions_enabled: 1
+    theme: "light"
 
 # Newsletter
 mailerlite:


### PR DESCRIPTION
NB: This branch was worked on using Manus AI, as I do not find value in doing a switch in comments for a blog a valuable use of time for me.

It used the following helper scripts to help with the migration as well:



This PR achieves the following:

- Replace Disqus comment provider with Giscus
- Giscus uses GitHub Discussions (no ads, no tracking)
- Supports reactions and threaded comments
- Uses the Announcements category for discussions
- Maps discussions to posts by pathname